### PR TITLE
Remove references to thoughtbot from gemspec

### DIFF
--- a/tirantes.gemspec
+++ b/tirantes.gemspec
@@ -9,25 +9,23 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~>4.2.0'
   s.add_development_dependency 'aruba', '~> 0.5.2'
   s.add_development_dependency 'cucumber', '~> 1.2'
-  s.authors = ['thoughtbot']
+  s.authors = ['Mario Chavez']
   s.date = Date.today.strftime('%Y-%m-%d')
 
   s.description = <<-HERE
-Tirantes is a base Rails project that you can upgrade. It is used by
-thoughtbot to get a jump start on a working app. Use Suspenders if you're in a
-rush to build something amazing; don't use it if you like missing deadlines.
+Tirantes is a base Rails project that you can upgrade.
   HERE
 
-  s.email = 'support@thoughtbot.com'
+  s.email = 'mario.chavez@gmail.com'
   s.executables = `git ls-files -- bin/*`.split("\n").map { |file| File.basename(file) }
   s.extra_rdoc_files = %w[README.md LICENSE]
   s.files = `git ls-files`.split("\n")
-  s.homepage = 'http://github.com/thoughtbot/suspenders'
+  s.homepage = 'https://github.com/mariochavez/tirantes'
   s.license = 'MIT'
   s.name = 'tirantes'
   s.rdoc_options = ['--charset=UTF-8']
   s.require_paths = ['lib']
-  s.summary = "Generate a Rails app using thoughtbot's best practices."
+  s.summary = "Generate a Rails app"
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = Tirantes::VERSION
 end


### PR DESCRIPTION
You missed references to thoughtbot in a few places. I just wanted to make sure there wasn't any confusion here. You probably want to go through the project and change the rest of the references as well.
